### PR TITLE
extend farming (and add ethereal) support

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name=signs_bot
 depends = default,farming,basic_materials,tubelib2
-optional_depends = node_io,techage,doc,minecart,bucket,fire,xdecor
+optional_depends = node_io,techage,doc,minecart,bucket,fire,xdecor,ethereal
 description = A robot controlled by signs

--- a/nodes.lua
+++ b/nodes.lua
@@ -50,8 +50,11 @@ end
 -- Farming Redo
 -------------------------------------------------------------------------------
 if farming.mod == "redo" then
-	for _, def in pairs(farming.registered_plants) do
-		fp(def.seed, def.crop .. "_1", def.crop .. "_" .. def.steps, def.trellis)
+	for name, def in pairs(farming.registered_plants) do
+		-- everything except cocoa (these can only be placed on jungletree)
+		if name ~= "farming:cocoa_beans" then
+			fp(def.seed, def.crop .. "_1", def.crop .. "_" .. def.steps, def.trellis)
+		end
 	end
 end
 

--- a/nodes.lua
+++ b/nodes.lua
@@ -44,42 +44,14 @@ end
 -- Farming Redo
 -------------------------------------------------------------------------------
 if farming.mod == "redo" then
-	fp("farming:seed_wheat", "farming:wheat_1", "farming:wheat_8")
-	fp("farming:seed_cotton", "farming:cotton_1", "farming:cotton_8")
-	fp("farming:carrot", "farming:carrot_1", "farming:carrot_8")
-	fp("farming:potato", "farming:potato_1", "farming:potato_4")
-	fp("farming:tomato", "farming:tomato_1", "farming:tomato_8")
-	fp("farming:cucumber", "farming:cucumber_1", "farming:cucumber_4")
-	fp("farming:corn", "farming:corn_1", "farming:corn_8")
-	fp("farming:coffee_beans", "farming:coffee_1", "farming:coffee_5")
-	fp("farming:melon_slice", "farming:melon_1", "farming:melon_8")
-	fp("farming:pumpkin_slice", "farming:pumpkin_1", "farming:pumpkin_8")
-	fp("farming:raspberries", "farming:raspberry_1", "farming:raspberry_4")
-	fp("farming:blueberries", "farming:blueberry_1", "farming:blueberry_4")
-	fp("farming:rhubarb", "farming:rhubarb_1", "farming:rhubarb_3")
-	fp("farming:beans", "farming:beanpole_1", "farming:beanpole_5")
-	fp("farming:grapes", "farming:grapes_1", "farming:grapes_8")
-	fp("farming:seed_barley", "farming:barley_1", "farming:barley_7")
-	fp("farming:chili_pepper", "farming:chili_1", "farming:chili_8")
-	fp("farming:seed_hemp", "farming:hemp_1", "farming:hemp_8")
-	fp("farming:seed_oat", "farming:oat_1", "farming:oat_8")
-	fp("farming:seed_rye", "farming:rye_1", "farming:rye_8")
-	fp("farming:seed_rice", "farming:rice_1", "farming:rice_8")
-	fp("farming:beetroot", "farming:beetroot_1", "farming:beetroot_5")
-	fp("farming:cocoa_beans", "farming:cocoa_1", "farming:cocoa_4")
-	fp("farming:garlic_clove", "farming:garlic_1", "farming:garlic_5")
-	fp("farming:onion", "farming:onion_1", "farming:onion_5")
-	fp("farming:pea_pod", "farming:pea_1", "farming:pea_5")
-	fp("farming:peppercorn", "farming:pepper_1", "farming:pepper_5")
-	fp("farming:pineapple_top", "farming:pineapple_1", "farming:pineapple_8")
+	for _, def in pairs(farming.registered_plants) do
+		fp(def.seed, def.crop .. "_1", def.crop .. "_" .. def.steps)
+	end
 end
 
 -------------------------------------------------------------------------------
 -- Ethereal Farming
 -------------------------------------------------------------------------------
---fn("ethereal:strawberry_8",   "ethereal:strawberry 2",	     "ethereal:strawberry 1")
---fn("ethereal:onion_5",		  "ethereal:wild_onion_plant 2", "ethereal:onion_1")
-
 
 --fn("ethereal:willow_trunk",   "ethereal:willow_trunk", "ethereal:willow_sapling")
 --fn("ethereal:redwood_trunk",  "ethereal:redwood_trunk",  "ethereal:redwood_sapling")

--- a/nodes.lua
+++ b/nodes.lua
@@ -14,14 +14,20 @@
 
 signs_bot.FarmingSeed = {}
 signs_bot.FarmingCrop = {}
+signs_bot.FarmingNeedTrellis = {}
+signs_bot.FarmingKeepTrellis = {}
 signs_bot.TreeSaplings = {}
 
 -- inv_seed is the seed inventory name
 -- plantlet is what has to be placed on the ground (stage 1)
 -- crop is the farming crop in the final stage
-function signs_bot.register_farming_plant(inv_seed, plantlet, crop)
+function signs_bot.register_farming_plant(inv_seed, plantlet, crop, trellis)
 	signs_bot.FarmingCrop[crop] = true
 	signs_bot.FarmingSeed[inv_seed] = plantlet
+	if trellis then
+		signs_bot.FarmingNeedTrellis[plantlet] = trellis
+		signs_bot.FarmingKeepTrellis[crop] = trellis
+	end
 end
 
 -- inv_sapling is the sapling inventory name
@@ -45,7 +51,7 @@ end
 -------------------------------------------------------------------------------
 if farming.mod == "redo" then
 	for _, def in pairs(farming.registered_plants) do
-		fp(def.seed, def.crop .. "_1", def.crop .. "_" .. def.steps)
+		fp(def.seed, def.crop .. "_1", def.crop .. "_" .. def.steps, def.trellis)
 	end
 end
 


### PR DESCRIPTION
This PR adds `harvest` and `sow_seed` support for further "farming" nodes (vanilla, artichoke, cabbage, sunflower, lettuce, soy_pod, blackberry, mint, parsley) by using `farming.registered_plants`. (commit https://github.com/joe7575/signs_bot/commit/6701f4f4af28ed418b15833dbd38bcad859e49d5)
(a related bugfix https://notabug.org/TenPlus1/farming/commit/8be42d5f636923b2ec7bb01110e973dcbececd21)

Commit https://github.com/joe7575/signs_bot/commit/e49471a46735cecbddc8bf7e371dbfc80f6cbb07  adds support for "ethereal:wild_onion_plant" and "ethereal:strawberry".
(With https://notabug.org/TenPlus1/ethereal/commit/d22d8a3986744c099326110d5c25cde33ac4ded1 or later)

Commit https://github.com/joe7575/signs_bot/commit/d7e264fe9cfb6567934be4a40b3abeea3c804220  Fixes a bug with "beans" and "grapes".
Trellis (by that I mean "farming:beanpole" and "farming:trellis") have not been placed, but "harvested".
"beans" and "grapes" are now only be seeded if suitable trellis are placed. 
When harvesting, the trellis are now left standing. 
This behavior seems to me the most compatible with existing fields.
(With https://notabug.org/TenPlus1/farming/commit/3cbbb3678e8e0f24a75d28496ddbba71cb5afa32 or later. With older version the existing behavior remains)
