### PR TITLE
supports multiple harvesting stages (for farming:pepper)

### DIFF
--- a/nodes.lua
+++ b/nodes.lua
@@ -50,10 +50,20 @@ end
 -- Farming Redo
 -------------------------------------------------------------------------------
 if farming.mod == "redo" then
+	local fp_grows = function(def, step)
+		local crop = def.crop .. "_" .. step
+	        local node = minetest.registered_nodes[crop]
+		if node then
+			fp(def.seed, def.crop .. "_1", crop, def.trellis)
+			return node.groups and node.groups.growing
+		end
+	end
+
 	for name, def in pairs(farming.registered_plants) do
 		-- everything except cocoa (these can only be placed on jungletree)
 		if name ~= "farming:cocoa_beans" then
-			fp(def.seed, def.crop .. "_1", def.crop .. "_" .. def.steps, def.trellis)
+			local step = def.steps
+			while fp_grows(def, step) do step = step + 1 end
 		end
 	end
 end


### PR DESCRIPTION
farming:pepper has 3 harvesting stages:
- stage 5 (green pepper)
- stage 6 (yellow pepper)
- stage 7 (red pepper)

See also: https://notabug.org/TenPlus1/farming/src/master/crops/pepper.lua#L114-L155

The bot only knows level 5 so far.
With this PR stage  6 and 7 are also detected by the sensor and also harvested by the bot.

This change are successfully tested with Minetest 5.4.1 (and minetest_game) and 3x3 field with sensor. Each for:
- farmin:beanpole,
- farming:grapes,
- ethereal:onion,
- ethereal:strawberry,
- farming:rice,
- farming:wheat
- farming:pea
- farming:pepper

and this a sign_cmnd:

```
turn_right
harvest
sow_seed 1
move 3
exit
```
