### PR TITLE
[WIP] Fix disconnected Bots after Server-Crash

### DIFF
--- a/basis.lua
+++ b/basis.lua
@@ -232,6 +232,7 @@ function signs_bot.start_robot(base_pos)
 		signs_bot.infotext(base_pos, S("running"))
 		reset_robot(base_pos, mem)
 		minetest.get_node_timer(base_pos):start(CYCLE_TIME)
+		tubelib2.save_mem(base_pos)
 		return true
 	end
 end
@@ -255,6 +256,7 @@ function signs_bot.stop_robot(base_pos, mem)
 		end
 		meta:set_string("formspec", formspec(base_pos, mem))
 		signs_bot.remove_robot(mem)
+		tubelib2.save_mem(base_pos)
 	else
 		mem.signal_request = false
 		signs_bot.start_robot(base_pos)

--- a/cmd_move.lua
+++ b/cmd_move.lua
@@ -134,6 +134,7 @@ signs_bot.register_botcommand("backward", {
 		local new_pos = backward_robot(mem)
 		if new_pos then  -- not blocked?
 			mem.robot_pos = new_pos
+			tubelib2.save_mem(base_pos)
 		end
 		return signs_bot.DONE
 	end,
@@ -216,6 +217,7 @@ signs_bot.register_botcommand("move_up", {
 		local new_pos = robot_up(mem.robot_pos, mem.robot_param2)
 		if new_pos then  -- not blocked?
 			mem.robot_pos = new_pos
+			tubelib2.save_mem(base_pos)
 		end
 		return signs_bot.DONE
 	end,
@@ -250,6 +252,7 @@ signs_bot.register_botcommand("move_down", {
 		local new_pos = robot_down(mem.robot_pos, mem.robot_param2)
 		if new_pos then  -- not blocked?
 			mem.robot_pos = new_pos
+			tubelib2.save_mem(base_pos)
 		end
 		return signs_bot.DONE
 	end,

--- a/commands.lua
+++ b/commands.lua
@@ -229,10 +229,11 @@ signs_bot.register_botcommand("jump", {
 	description = S("jump to a label"),
 })	
 
-local function move(mem, any_sensor)
+local function move(base_pos, mem, any_sensor)
 	local new_pos = signs_bot.move_robot(mem)
 	if new_pos then  -- not blocked?
 		mem.robot_pos = new_pos
+		tubelib2.save_mem(base_pos)
 		if any_sensor then
 			activate_sensor(mem.robot_pos, (mem.robot_param2 + 1) % 4)
 			activate_sensor(mem.robot_pos, (mem.robot_param2 + 3) % 4)
@@ -257,7 +258,7 @@ counted as steps.]]),
 	cmnd = function(base_pos, mem, steps)
 		steps = tonumber(steps) or 1
 		local res, idx = signs_bot.steps(mem, 1, steps)
-		move(mem, scan_surrounding(mem))
+		move(base_pos, mem, scan_surrounding(mem))
 		return res
 	end,
 })
@@ -275,7 +276,7 @@ new program from the sign]]),
 	cmnd = function(base_pos, mem)
 		local any_sensor, sign_pos = scan_surrounding(mem)
 		if not sign_pos then
-			move(mem, any_sensor)
+			move(base_pos, mem, any_sensor)
 			return ci.BUSY
 		else
 			mem.script = M(sign_pos):get_string("signs_bot_cmnd").."\ncond_move"


### PR DESCRIPTION
If the signs_bot is running during a server crash, it will stand disconnected from the box afer a server restart. The box will then start a new bot, which may be affected by the disconnected one.

I can reproduce this behavior as follows:
- place a `signs_bot:box` and 2 blocks to the right of it a `signs_bot:sign_cmnd` with this program:
```
turn_right

repeat 20
 move 1
 end
exit
```
- turn on the box, wait about 4 seconds and then kill the server
```
~$ kill -kill  $(pidof minetest)
```
- after the restart you have a new and the old bot.

This PR fixes the problem by calling the new function `tubelib2.save_mem(base_pos)` (see  https://github.com/joe7575/tubelib2/pull/14) after each change of `mem.robot_pos`.

Besides the above setup i have also tested it with this program:
```
turn_left

repeat 20
 backward
 end
exit
```

I am not sure yet to what extent this will affect the performance. Therefore [WIP]

*Edit*
Sorry for the early [WIP]-PR. I just wanted to make sure with the description here that not several issues get mixed up.