### PR TITLE
Fix command crash when running "print <num>"

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -302,7 +302,7 @@ instead of spaces, like "Hello*world"]]),
 		return text ~= ""
 	end,
 	cmnd = function(base_pos, mem, text)
-		text = text:gsub("*", " ")
+		text = tostring(text):gsub("%*", " ")
 		local owner = M(base_pos):get_string("owner")
 		if owner ~= "" and text ~= "" then
 			minetest.chat_send_player(owner, "Bot: " .. text)


### PR DESCRIPTION
`text` can be a number so it must be converted to a string before using string methods.

Fixes https://github.com/Archtec-io/bugtracker/issues/234