### PR TITLE
Fix compatibility with everness mod hammer functionality

### DIFF
--- a/lib.lua
+++ b/lib.lua
@@ -118,7 +118,8 @@ function signs_bot.lib.is_simple_node(node)
 		if not ndef or node.name == "air" then return false end
 		if ndef.drop == "" then return false end
 		if ndef.diggable == false then return false end
-		if ndef.after_dig_node then return false end
+		-- Allow digging nodes with after_dig_node only when everness is loaded
+		if ndef.after_dig_node and not minetest.get_modpath("everness") then return false end
 	end
 	if type(ndef.drop) == "table" then
 		return handle_drop(ndef.drop)


### PR DESCRIPTION
Remove restrictive after_dig_node check in is_simple_node function to allow signs_bot to dig nodes even when everness mod adds hammer functionality via after_dig_node callbacks. This resolves issue #48 where signs_bot refused to dig when everness was loaded.